### PR TITLE
Autocomplete Support

### DIFF
--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -110,6 +110,11 @@ namespace BooruSharp.Booru
         public bool HasFavoriteAPI => !_options.HasFlag(BooruOptions.NoFavorite);
 
         /// <summary>
+        /// Gets whether it is possible to autocomplete searches in this booru.
+        /// </summary>
+        public bool HasAutocompleteAPI => !_options.HasFlag(BooruOptions.NoAutocomplete);
+
+        /// <summary>
         /// Gets whether this booru can't call post functions without search arguments.
         /// </summary>
         public bool NoEmptyPostSearch => _options.HasFlag(BooruOptions.NoEmptyPostSearch);

--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -45,6 +45,8 @@ namespace BooruSharp.Booru
         private protected virtual Search.Wiki.SearchResult GetWikiSearchResult(object json)
             => throw new FeatureUnavailable();
 
+        private protected virtual Search.Autocomplete.SearchResult[] GetAutocompleteResultAsync(object json)
+            => throw new FeatureUnavailable();
         private protected virtual async Task<IEnumerable> GetTagEnumerableSearchResultAsync(Uri url)
         {
             if (TagsUseXml)
@@ -203,6 +205,23 @@ namespace BooruSharp.Booru
 
             if (HasCommentAPI)
                 _commentUrl = CreateQueryString(format, "comment");
+
+            if (HasAutocompleteAPI)
+                _autocompleteUrl = format == UrlFormat.IndexPhp
+                    ? new Uri(BaseUrl + "autocomplete.php")
+                    : CreateQueryString(format, "autocomplete");
+            switch (_format)
+            {
+                case UrlFormat.IndexPhp:
+                    _autocompleteUrl = new Uri(BaseUrl + "autocomplete.php");
+                    break;
+                case UrlFormat.Danbooru:
+                    _autocompleteUrl = new Uri(BaseUrl + "tags/" + "autocomplete.json");
+                    break;
+                default:
+                    _autocompleteUrl = CreateQueryString(_format, "autocomplete"); //this isn't supposed to work.
+                    break;
+            }
         }
 
         private protected Uri CreateQueryString(UrlFormat format, string query, string squery = "index")
@@ -360,7 +379,7 @@ namespace BooruSharp.Booru
         public Uri BaseUrl { get; }
 
         private HttpClient _client;
-        private readonly Uri _imageUrlXml, _imageUrl, _tagUrl, _wikiUrl, _relatedUrl, _commentUrl; // URLs for differents endpoints
+        private readonly Uri _imageUrlXml, _imageUrl, _tagUrl, _wikiUrl, _relatedUrl, _commentUrl, _autocompleteUrl; // URLs for differents endpoints
         // All options are stored in a bit field and can be retrieved using related methods/properties.
         private readonly BooruOptions _options;
         private readonly UrlFormat _format; // URL format

--- a/BooruSharp/Booru/BooruOptions.cs
+++ b/BooruSharp/Booru/BooruOptions.cs
@@ -78,5 +78,10 @@ namespace BooruSharp.Booru
         /// Indicates that search parameter must be provided in order for post search functions to work.
         /// </summary>
         NoEmptyPostSearch = 1 << 15,
+
+        /// <summary>
+        /// Indicates that the search autocomplete API is not avaliable.
+        /// </summary>
+        NoAutocomplete = 1 << 16,
     }
 }

--- a/BooruSharp/Booru/Template/BooruOnRails.cs
+++ b/BooruSharp/Booru/Template/BooruOnRails.cs
@@ -26,7 +26,7 @@ namespace BooruSharp.Booru.Template
         /// </param>
         protected BooruOnRails(string domain, BooruOptions options = BooruOptions.None)
             : base(domain, UrlFormat.BooruOnRails, options | BooruOptions.NoFavorite | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID
-                  | BooruOptions.NoLastComments | BooruOptions.NoWiki | BooruOptions.NoRelated)
+                  | BooruOptions.NoLastComments | BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.NoAutocomplete)
         { }
 
         /// <summary>

--- a/BooruSharp/Booru/Template/Danbooru.cs
+++ b/BooruSharp/Booru/Template/Danbooru.cs
@@ -23,7 +23,7 @@ namespace BooruSharp.Booru.Template
         /// </param>
         protected Danbooru(string domain, BooruOptions options = BooruOptions.None)
             : base(domain, UrlFormat.Danbooru, options | BooruOptions.NoLastComments | BooruOptions.NoPostCount
-                  | BooruOptions.NoFavorite)
+                  | BooruOptions.NoFavorite | BooruOptions.NoAutocomplete)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Template/E621.cs
+++ b/BooruSharp/Booru/Template/E621.cs
@@ -146,11 +146,26 @@ namespace BooruSharp.Booru.Template
                 int id = item["id"].Value<int>();
                 string name = item["name"].Value<string>();
                 int count = item["post_count"].Value<int>();
-                int type = item["category"].Value<int>();
+                var type = GetTagType(item["category"].Value<int>());
                 string antecedent_name = item["antecedent_name"].Value<string>();
-                autoCompleteResults.Add(new Search.Autocomplete.SearchResult(id, name, name, null, count, antecedent_name));
+                autoCompleteResults.Add(new Search.Autocomplete.SearchResult(id, name, name, type, count, antecedent_name));
             }
             return autoCompleteResults.ToArray();
+        }
+
+        private Search.Tag.TagType GetTagType(int typeNum)
+        {
+            switch (typeNum)
+            {
+                case 5: return Search.Tag.TagType.Species;
+                case 8: return Search.Tag.TagType.Lore;
+                case 0: return Search.Tag.TagType.Trivia;
+                case 4: return Search.Tag.TagType.Character;
+                case 3: return Search.Tag.TagType.Copyright;
+                case 1: return Search.Tag.TagType.Artist;
+                case 7: return Search.Tag.TagType.Metadata;
+                default: return (Search.Tag.TagType)6; //i won't question...
+            }
         }
     }
 }

--- a/BooruSharp/Booru/Template/E621.cs
+++ b/BooruSharp/Booru/Template/E621.cs
@@ -136,5 +136,21 @@ namespace BooruSharp.Booru.Template
         }
 
         // GetRelatedSearchResult not available // TODO: Available with credentials?
+
+        private protected override Search.Autocomplete.SearchResult[] GetAutocompleteResultAsync(object json)
+        {
+            var elem = (JArray)json;
+            var autoCompleteResults = new List<Search.Autocomplete.SearchResult>();
+            foreach (var item in elem.Children())
+            {
+                int id = item["id"].Value<int>();
+                string name = item["name"].Value<string>();
+                int count = item["post_count"].Value<int>();
+                int type = item["category"].Value<int>();
+                string antecedent_name = item["antecedent_name"].Value<string>();
+                autoCompleteResults.Add(new Search.Autocomplete.SearchResult(id, name, name, null, count, antecedent_name));
+            }
+            return autoCompleteResults.ToArray();
+        }
     }
 }

--- a/BooruSharp/Booru/Template/Gelbooru.cs
+++ b/BooruSharp/Booru/Template/Gelbooru.cs
@@ -175,10 +175,22 @@ namespace BooruSharp.Booru.Template
                 string label = item["label"].Value<string>();
                 string name = item["value"].Value<string>();
                 int count = item["post_count"].Value<int>();
-                var type = item["category"].Value<string>();
-                autoCompleteResults.Add(new Search.Autocomplete.SearchResult(null, name, label, null, count, null));
+                var type = GetTagType(item["category"].Value<string>());
+                autoCompleteResults.Add(new Search.Autocomplete.SearchResult(null, name, label, type, count, null));
             }
             return autoCompleteResults.ToArray();
+        }
+        private Search.Tag.TagType GetTagType(string typeName)
+        {
+            switch (typeName)
+            {
+                case "tag": return Search.Tag.TagType.Trivia;
+                case "character": return Search.Tag.TagType.Character;
+                case "copyright": return Search.Tag.TagType.Copyright;
+                case "artist": return Search.Tag.TagType.Artist;
+                case "metadata": return Search.Tag.TagType.Metadata;
+                default: return (Search.Tag.TagType)6; //i won't question...
+            }
         }
     }
 }

--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -1,5 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -109,6 +111,20 @@ namespace BooruSharp.Booru.Template
         }
 
         // GetRelatedSearchResult not available
+
+        private protected override Search.Autocomplete.SearchResult[] GetAutocompleteResultAsync(object json)
+        {
+            var elem = (JArray)json;
+            var autoCompleteResults = new List<Search.Autocomplete.SearchResult>();
+            foreach (var item in elem.Children())
+            {
+                string label = item["label"].Value<string>();
+                string name = item["value"].Value<string>();
+                int count = Convert.ToInt32(Regex.Match(label, @"\(([^()]*)\)$").Groups[1].Value); //this should always work
+                autoCompleteResults.Add(new Search.Autocomplete.SearchResult(null, name, label, null, count, null));
+            }
+            return autoCompleteResults.ToArray();
+        }
 
         private readonly string _url;
     }

--- a/BooruSharp/Booru/Template/Moebooru.cs
+++ b/BooruSharp/Booru/Template/Moebooru.cs
@@ -22,7 +22,7 @@ namespace BooruSharp.Booru.Template
         /// </param>
         protected Moebooru(string domain, BooruOptions options = BooruOptions.None)
             : base(domain, UrlFormat.PostIndexJson, options | BooruOptions.NoPostByMD5
-                  | BooruOptions.NoFavorite)
+                  | BooruOptions.NoFavorite | BooruOptions.NoAutocomplete)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Template/Philomena.cs
+++ b/BooruSharp/Booru/Template/Philomena.cs
@@ -26,7 +26,7 @@ namespace BooruSharp.Booru.Template
         /// </param>
         protected Philomena(string domain, BooruOptions options = BooruOptions.None)
             : base(domain, UrlFormat.Philomena, options | BooruOptions.NoFavorite | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID
-                  | BooruOptions.NoLastComments | BooruOptions.NoWiki | BooruOptions.NoRelated)
+                  | BooruOptions.NoLastComments | BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.NoAutocomplete)
         { }
 
         /// <summary>

--- a/BooruSharp/Search/Autocomplete/ABooru.cs
+++ b/BooruSharp/Search/Autocomplete/ABooru.cs
@@ -1,9 +1,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using System.Xml;
 
 namespace BooruSharp.Booru
 {

--- a/BooruSharp/Search/Autocomplete/ABooru.cs
+++ b/BooruSharp/Search/Autocomplete/ABooru.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace BooruSharp.Booru
+{
+    public abstract partial class ABooru
+    {
+        /// <summary>
+        /// Gets a result of autocomplete options from a tag slice
+        /// </summary>
+        /// <param name="query">The tag slice to autocomplete</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        public virtual async Task<Search.Autocomplete.SearchResult[]> AutocompleteAsync(string query)
+        {
+            if (!HasAutocompleteAPI)
+                throw new Search.FeatureUnavailable();
+
+
+            Uri url = _format == UrlFormat.Danbooru
+                ? CreateUrl(_autocompleteUrl, SearchArg("name_matches") + query)
+                : CreateUrl(_autocompleteUrl, SearchArg("q") + query);
+
+            var array = JsonConvert.DeserializeObject<JArray>(await GetJsonAsync(url));
+
+            return GetAutocompleteResultAsync(array);
+        }
+    }
+}

--- a/BooruSharp/Search/Autocomplete/SearchResult.cs
+++ b/BooruSharp/Search/Autocomplete/SearchResult.cs
@@ -1,0 +1,63 @@
+using BooruSharp.Search.Tag;
+
+namespace BooruSharp.Search.Autocomplete
+{
+    ///<summary>
+    /// Represents an autocomplete API search result.
+    ///</summary>
+    public readonly struct SearchResult
+    {
+        /// <summary>
+        /// Initializes a <see cref="SearchResult"/> struct.
+        /// </summary>
+        /// <param name="id">The ID of the tag.</param>
+        /// <param name="name">The name of the tag.</param>
+        /// <param name="label">The label (display name) of the tag.</param>
+        /// <param name="type">The type of the tag.</param>
+        /// <param name="count">The number of occurences of the tag.</param>
+        /// <param name="antecedent_name">The previous name of the tag.</param>
+        public SearchResult(int? id, string name, string label, TagType? type, int count, string antecedent_name)
+        {
+            TagID = id;
+            Label = label;
+            Name = name;
+            Type = type;
+            Count = count;
+            AntecedentName = antecedent_name;
+        }
+
+        /// <summary>
+        /// Gets the ID of the tag.
+        /// <see langword="null"/> if not on E621 or E926.
+        /// </summary>
+        public int? TagID { get; }
+
+        /// <summary>
+        /// Gets the label (display name) of the tag.
+        /// </summary>
+        public string Label { get; }
+
+        /// <summary>
+        /// Gets the name of the tag.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the type of the tag.
+        /// <see langword="null"/> if on GelBooru02
+        /// </summary>
+        /// Also known as "category".
+        public TagType? Type { get; }
+
+        /// <summary>
+        /// Gets the number of occurences of the tag.
+        /// </summary>
+        public int Count { get; }
+
+        /// <summary>
+        /// Gets the previous name of the tag.
+        /// <see langword="null"/> if not on E621 or E926.
+        /// </summary> 
+        public string AntecedentName { get; }
+    }
+}


### PR DESCRIPTION
Merges the autocomplete feature into Lucius-Macarini/BooruSharp master branch.

This search result autocompletes a tag slice passed in as a query.
It is only avaliable for E621/E926, GelBooru and GelBooru02
(though Danbooru Donmai and Sankaku Complex support could probably be added later).

Example (E926):
Trying to aucomplete "syl" will return the tags "hybrid", "sylveon", "sylvanedadeer" and etc. just like the site's own autocomplete box

The returned tags have some similarity to tags searched individualy with the tag search feature but they are prety different.